### PR TITLE
chore: add claude.yml for interactive @claude responses

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -34,30 +34,18 @@ on:
     types: [opened, ready_for_review, reopened]
     paths-ignore:
       - '**.md'
-  # Interactive @claude mentions in PR conversations.
-  # These triggers have no paths filter — @claude works on any PR regardless
-  # of which files changed. The plugin's triage agent skips drafts.
-  issue_comment:
-    types: [created]
-  pull_request_review_comment:
-    types: [created]
 
-# One review per PR at a time. cancel-in-progress is off for comment
-# events so the action's own tracking comment doesn't kill the review.
+# One automated review per PR at a time.
 concurrency:
-  group: claude-review-${{ github.event_name }}-${{ github.event.pull_request.number || github.event.issue.number }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
 
 jobs:
   review:
     # Non-blocking — never gates merges.
     continue-on-error: true
-    # PR events: skip drafts (plugin also triages these, but this is a second layer).
-    # Comment events: only respond to explicit @claude mentions.
-    if: |
-      (github.event_name == 'pull_request' && !github.event.pull_request.draft) ||
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude'))
+    # Skip draft PRs — review fires when the PR is opened or marked ready.
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,33 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude'))
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 50
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: |
+            --model claude-fable-5
+            --system-prompt "You are an assistant for the MagicSchoolAi/nix-ops repository, which defines the Nix development environment used by all MagicSchool engineers. The repo is a Nix Flake with custom derivations in mods/pkgs/ and the shared dev environment in mods/external.nix. A broken build or bad derivation blocks every engineer's direnv shell. When reviewing PRs, pay special attention to hash integrity, supply chain risks (unexpected owner/repo changes), cross-platform compatibility (linux + darwin), and Cachix cache impact. Review format and severity guidelines are in .claude/resources/pr-review-format.md."


### PR DESCRIPTION
## Summary

- Adds `claude.yml` for interactive `@claude` mentions — handles re-review requests and questions as a general assistant with Nix-specific context
- Removes `issue_comment`/`pull_request_review_comment` triggers from `claude-review.yml` (the code-review plugin fails silently in tag mode; those triggers now belong to `claude.yml`)
- Simplifies `claude-review.yml` concurrency and `if` condition now that it's `pull_request`-only

Matches the pattern ops already uses: one workflow for automated review on open/reopen, one for interactive `@claude` responses.

## Test plan

- [ ] After merge, comment `@claude please review this PR` on an open PR — confirm Claude responds conversationally with review feedback
- [ ] Comment `@claude` with a specific question — confirm Claude answers it
- [ ] Open a new PR — confirm the automated code-review plugin still runs and posts findings as before